### PR TITLE
Enhance History with Detailed Location Names

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The INTERNET permission is required for development. Specifically,
+         the Flutter tool needs it to communicate with the running application
+         to allow setting breakpoints, to provide hot reload, etc.  
+    -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+
     <application
         android:label="open_street_map_example"
         android:name="${applicationName}"

--- a/lib/history.dart
+++ b/lib/history.dart
@@ -1,0 +1,144 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:location/location.dart';
+
+class HistoryScreen extends StatefulWidget {
+  final List<Map<String, dynamic>> history;
+
+  const HistoryScreen({super.key, required this.history});
+
+  @override
+  _HistoryScreenState createState() => _HistoryScreenState();
+}
+
+class _HistoryScreenState extends State<HistoryScreen> {
+  LocationData? _currentLocation;
+  final Location _location = Location();
+
+  @override
+  void initState() {
+    super.initState();
+    _getCurrentLocation();
+  }
+
+  Future<void> _getCurrentLocation() async {
+    try {
+      final locationData = await _location.getLocation();
+      setState(() {
+        _currentLocation = locationData;
+      });
+    } catch (e) {
+      log("Error getting location: $e");
+    }
+  }
+
+  String _getLocationName(Map<String, dynamic> item) {
+    if (item['type'] == 'search') {
+      return item['name'];
+    } else {
+      return 'Route: ${item['start']['name']} to ${item['end']['name']}';
+    }
+  }
+
+  String _getDistanceString(Map<String, dynamic> item) {
+    if (_currentLocation == null) {
+      return 'Calculating...';
+    }
+
+    const Distance distance = Distance();
+    double distanceInMeters;
+
+    if (item['type'] == 'search') {
+      distanceInMeters = distance.as(
+        LengthUnit.Meter,
+        LatLng(_currentLocation!.latitude!, _currentLocation!.longitude!),
+        LatLng(item['lat'], item['lon']),
+      );
+    } else {
+      distanceInMeters = distance.as(
+        LengthUnit.Meter,
+        LatLng(_currentLocation!.latitude!, _currentLocation!.longitude!),
+        LatLng(item['end']['lat'], item['end']['lon']),
+      );
+    }
+
+    if (distanceInMeters < 1000) {
+      return '${distanceInMeters.toStringAsFixed(0)} m';
+    } else {
+      return '${(distanceInMeters / 1000).toStringAsFixed(2)} km';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Search and Route History'),
+        flexibleSpace: Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Colors.teal, Colors.green],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+        ),
+      ),
+      body: widget.history.isEmpty
+          ? Center(
+              child: Text("No history available.",
+                  style: TextStyle(fontSize: 18, color: Colors.grey[700])))
+          : ListView.builder(
+              itemCount: widget.history.length,
+              itemBuilder: (context, index) {
+                final item = widget.history[index];
+                final icon =
+                    item['type'] == 'search' ? Icons.search : Icons.directions;
+                final locationName = _getLocationName(item);
+                final distance = _getDistanceString(item);
+                final dateTime = DateTime.parse(item['timestamp']);
+                final formattedDate =
+                    DateFormat('MMM d, y HH:mm').format(dateTime);
+
+                return Card(
+                  margin:
+                      const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+                  elevation: 6,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: Colors.teal,
+                      child: Icon(icon, color: Colors.white),
+                    ),
+                    title: Text(locationName,
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(distance, style: const TextStyle(fontSize: 16)),
+                        Text(formattedDate,
+                            style: const TextStyle(
+                                fontSize: 12, color: Colors.grey)),
+                      ],
+                    ),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete, color: Colors.red),
+                      onPressed: () {
+                        setState(() {
+                          widget.history.removeAt(index);
+                        });
+                      },
+                    ),
+                    onTap: () {},
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -4,11 +4,12 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
 import 'package:location/location.dart';
+import 'package:open_street_map_example/history.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
@@ -29,16 +30,131 @@ class _MapScreenState extends State<MapScreen> {
   bool _isSearching = false;
   bool _isSatelliteView = false;
   Timer? _debounce;
+  bool _isFollowingUser = false;
+  StreamSubscription<LocationData>? _locationSubscription;
+  List<Map<String, dynamic>> _history = [];
 
   @override
   void initState() {
     super.initState();
     _getCurrentLocation();
+    _loadHistory();
+  }
+
+  Future<void> _loadHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    final historyJson = prefs.getString('search_history');
+    if (historyJson != null) {
+      setState(() {
+        _history = List<Map<String, dynamic>>.from(json.decode(historyJson));
+      });
+    }
+  }
+
+  Future<void> _saveHistory() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('search_history', json.encode(_history));
+  }
+
+  Future<String> _getLocationName(double lat, double lon) async {
+    try {
+      final response = await http.get(
+        Uri.parse(
+          'https://nominatim.openstreetmap.org/reverse?format=json&lat=$lat&lon=$lon&zoom=18&addressdetails=1',
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body);
+        return data['display_name'];
+      }
+    } catch (e) {
+      print("Error in reverse geocoding: $e");
+    }
+    return 'Unknown location';
+  }
+
+  Future<void> _addToHistory(Map<String, dynamic> item) async {
+    if (item['type'] == 'search') {
+      _history.insert(0, {
+        'type': 'search',
+        'name': item['name'],
+        'lat': item['lat'],
+        'lon': item['lon'],
+        'timestamp': DateTime.now().toIso8601String(),
+      });
+    } else if (item['type'] == 'route') {
+      String startName =
+          await _getLocationName(item['start']['lat'], item['start']['lon']);
+      String endName =
+          await _getLocationName(item['end']['lat'], item['end']['lon']);
+
+      _history.insert(0, {
+        'type': 'route',
+        'start': {
+          'name': startName,
+          'lat': item['start']['lat'],
+          'lon': item['start']['lon'],
+        },
+        'end': {
+          'name': endName,
+          'lat': item['end']['lat'],
+          'lon': item['end']['lon'],
+        },
+        'timestamp': DateTime.now().toIso8601String(),
+      });
+    }
+
+    if (_history.length > 10) {
+      _history.removeLast();
+    }
+    _saveHistory();
+    setState(() {}); // Trigger a rebuild to reflect the changes
+  }
+
+  void _selectSearchResult(Map<String, dynamic> result) {
+    final LatLng point = LatLng(result['lat'], result['lon']);
+    _mapController.move(point, 15.0);
+    _addDestinationMarker(point);
+    _addToHistory({
+      'type': 'search',
+      'name': result['name'],
+      'lat': result['lat'],
+      'lon': result['lon'],
+      'timestamp': DateTime.now().toIso8601String(),
+    });
+    setState(() {
+      _searchResults = [];
+      _searchController.clear();
+    });
+  }
+
+  void _addDestinationMarker(LatLng point) {
+    setState(() {
+      _markers.add(
+        Marker(
+          width: 80.0,
+          height: 80.0,
+          point: point,
+          child: const Icon(Icons.location_on, color: Colors.red, size: 40.0),
+        ),
+      );
+    });
+    final start =
+        LatLng(_currentLocation!.latitude!, _currentLocation!.longitude!);
+    _getRoute(start, point);
+    _addToHistory({
+      'type': 'route',
+      'start': {'lat': start.latitude, 'lon': start.longitude},
+      'end': {'lat': point.latitude, 'lon': point.longitude},
+      'timestamp': DateTime.now().toIso8601String(),
+    });
   }
 
   @override
   void dispose() {
     _debounce?.cancel();
+    _locationSubscription?.cancel();
     super.dispose();
   }
 
@@ -64,16 +180,23 @@ class _MapScreenState extends State<MapScreen> {
       setState(() {
         _updateCurrentLocationMarker();
       });
+
+      _locationSubscription =
+          location.onLocationChanged.listen((LocationData loc) {
+        setState(() {
+          _currentLocation = loc;
+          _updateCurrentLocationMarker();
+          if (_isFollowingUser) {
+            _mapController.move(
+                LatLng(
+                    _currentLocation!.latitude!, _currentLocation!.longitude!),
+                15.0);
+          }
+        });
+      });
     } catch (e) {
       log('Error getting location: $e');
     }
-
-    location.onLocationChanged.listen((LocationData loc) {
-      setState(() {
-        _currentLocation = loc;
-        _updateCurrentLocationMarker();
-      });
-    });
   }
 
   void _updateCurrentLocationMarker() {
@@ -83,11 +206,14 @@ class _MapScreenState extends State<MapScreen> {
       _markers.add(
         Marker(
           key: const Key('currentLocation'),
-          width: 80.0,
-          height: 80.0,
+          width: 60.0,
+          height: 60.0,
           point:
               LatLng(_currentLocation!.latitude!, _currentLocation!.longitude!),
-          child: const Icon(Icons.my_location, color: Colors.blue, size: 40),
+          child: const CustomPaint(
+            painter: CurrentLocationPainter(),
+            size: Size(60, 60),
+          ),
         ),
       );
     }
@@ -100,7 +226,7 @@ class _MapScreenState extends State<MapScreen> {
     try {
       final response = await http.get(
         Uri.parse(
-          'https://api.openrouteservice.org/v2/directions/driving-car?api_key=$_orsKey&start=${start.longitude},${start.latitude}&end=${end.longitude},${end.latitude}',
+          'https://api.openrouteservice.org/v2/directions/foot-walking?api_key=$_orsKey&start=${start.longitude},${start.latitude}&end=${end.longitude},${end.latitude}',
         ),
       );
 
@@ -129,22 +255,6 @@ class _MapScreenState extends State<MapScreen> {
     } finally {
       setState(() => _isSearching = false);
     }
-  }
-
-  void _addDestinationMarker(LatLng point) {
-    setState(() {
-      _markers.add(
-        Marker(
-          width: 80.0,
-          height: 80.0,
-          point: point,
-          child: const Icon(Icons.location_on, color: Colors.red, size: 40.0),
-        ),
-      );
-    });
-    final start =
-        LatLng(_currentLocation!.latitude!, _currentLocation!.longitude!);
-    _getRoute(start, point);
   }
 
   void _searchLocation(String query) {
@@ -179,16 +289,6 @@ class _MapScreenState extends State<MapScreen> {
     });
   }
 
-  void _selectSearchResult(Map<String, dynamic> result) {
-    final LatLng point = LatLng(result['lat'], result['lon']);
-    _mapController.move(point, 15.0);
-    _addDestinationMarker(point);
-    setState(() {
-      _searchResults = [];
-      _searchController.clear();
-    });
-  }
-
   void _showErrorSnackBar(String message) {
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text(message),
@@ -200,13 +300,25 @@ class _MapScreenState extends State<MapScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Enhanced Map'),
+        title: const Text('Map'),
         actions: [
           IconButton(
             icon: Icon(_isSatelliteView ? Icons.map : Icons.satellite),
             onPressed: () =>
                 setState(() => _isSatelliteView = !_isSatelliteView),
             tooltip: 'Toggle Satellite View',
+          ),
+          IconButton(
+            icon: const Icon(Icons.history),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => HistoryScreen(history: _history),
+                ),
+              );
+            },
+            tooltip: 'View History',
           ),
         ],
       ),
@@ -266,33 +378,12 @@ class _MapScreenState extends State<MapScreen> {
                               ? "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
                               : "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                         ),
-                        MarkerClusterLayerWidget(
-                          options: MarkerClusterLayerOptions(
-                            maxClusterRadius: 120,
-                            size: const Size(40, 40),
-                            markers: _markers,
-                            builder: (context, markers) {
-                              return Container(
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).primaryColor,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: Center(
-                                  child: Text(
-                                    markers.length.toString(),
-                                    style: const TextStyle(color: Colors.white),
-                                  ),
-                                ),
-                              );
-                            },
-                          ),
-                        ),
                         PolylineLayer(
                           polylines: [
                             Polyline(
                               points: _routePoints,
                               strokeWidth: 5.0,
-                               gradientColors: [
+                              gradientColors: [
                                 const Color(0xffE40303),
                                 const Color(0xffFF8C00),
                                 const Color(0xffFFED00),
@@ -300,6 +391,7 @@ class _MapScreenState extends State<MapScreen> {
                             ),
                           ],
                         ),
+                        MarkerLayer(markers: _markers),
                       ],
                     ),
             ),
@@ -310,16 +402,20 @@ class _MapScreenState extends State<MapScreen> {
         activeIcon: Icons.close,
         children: [
           SpeedDialChild(
-            child: const Icon(Icons.my_location),
-            label: 'Go to My Location',
+            child: Icon(
+                _isFollowingUser ? Icons.location_disabled : Icons.my_location),
+            label: _isFollowingUser ? 'Stop Following' : 'Follow My Location',
             onTap: () {
-              if (_currentLocation != null) {
-                _mapController.move(
-                  LatLng(_currentLocation!.latitude!,
-                      _currentLocation!.longitude!),
-                  15.0,
-                );
-              }
+              setState(() {
+                _isFollowingUser = !_isFollowingUser;
+                if (_isFollowingUser && _currentLocation != null) {
+                  _mapController.move(
+                    LatLng(_currentLocation!.latitude!,
+                        _currentLocation!.longitude!),
+                    18.0,
+                  );
+                }
+              });
             },
           ),
           SpeedDialChild(
@@ -337,4 +433,28 @@ class _MapScreenState extends State<MapScreen> {
       ),
     );
   }
+}
+
+class CurrentLocationPainter extends CustomPainter {
+  const CurrentLocationPainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint circlePaint = Paint()
+      ..color = Colors.blue.withOpacity(0.3)
+      ..style = PaintingStyle.fill;
+
+    final Paint dotPaint = Paint()
+      ..color = Colors.blue
+      ..style = PaintingStyle.fill;
+
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2;
+
+    canvas.drawCircle(center, radius, circlePaint);
+    canvas.drawCircle(center, radius / 4, dotPaint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import location
+import shared_preferences_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   LocationPlugin.register(with: registry.registrar(forPlugin: "LocationPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -169,7 +185,7 @@ packages:
     source: hosted
     version: "4.0.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
@@ -312,6 +328,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   platform:
     dependency: transitive
     description:
@@ -352,6 +392,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -501,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.5.3 <4.0.0"
   flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,9 +18,11 @@ dependencies:
   flutter_map_marker_cluster: ^1.4.0
   flutter_speed_dial: ^7.0.0
   http: ^1.2.2
+  intl: ^0.19.0
   latlong2: ^0.9.1
   location: ^7.0.1
   path: ^1.9.0
+  shared_preferences: ^2.3.2
   sqflite: ^2.4.0
 
 dev_dependencies:
@@ -32,7 +34,6 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg
-
   # fonts:
   #   - family: Schyler
   #     fonts:


### PR DESCRIPTION
This pull request improves the way location names are stored and displayed in the app's history feature. It introduces reverse geocoding to provide more meaningful and human-readable location information for both search results and route endpoints.

Key changes:
- Added a new `_getLocationName` method that uses the Nominatim API for reverse geocoding
- Updated the `_addToHistory` method to fetch and store detailed location names for route start and end points
- Maintained the existing structure for search history items
- Ensured the history still maintains a maximum of 10 items

These changes will significantly improve the user experience by providing more context and clarity in the history view, making it easier for users to recognize and recall their past searches and routes.

Note: This change introduces additional API calls to the Nominatim service. We should monitor usage and consider implementing caching or switching to a paid service if we expect high volume use.

Testing:
- Verified that search history items maintain their original names
- Confirmed that route history items now display detailed start and end location names
- Checked that the history limit of 10 items is still enforced
- Tested error handling when reverse geocoding fails

Next steps:
- Consider adding a loading indicator while fetching location names
- Implement caching for frequently accessed location names to reduce API calls
- Explore options for offline reverse geocoding for better performance and reduced reliance on network connectivity